### PR TITLE
Feeding cards for issue #1

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -53,4 +53,8 @@
       cursor: pointer;
       margin-bottom: 30px;
     }
+
+    .feedings .card {
+      @apply bg-white rounded-2xl shadow-md overflow-hidden border border-gray-200 flex items-center justify-start text-left px-4 py-4;
+    }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -55,6 +55,22 @@
     }
 
     .feedings .card {
-      @apply bg-white rounded-2xl shadow-md overflow-hidden border border-gray-200 flex items-center justify-start text-left px-4 py-4 mb-4;
+      @apply bg-white rounded-2xl shadow-md overflow-hidden border border-gray-200 flex items-center justify-start text-left mb-2 gap-2;
+    }
+
+    .feedings .card .brand-pill {
+      @apply inline-block px-2 py-1 ml-2 rounded-full text-xs text-white;
+    }
+    
+    .brand-pill[data-brand="Fancy Feast"] {
+      @apply bg-purple-500;
+    }
+    
+    .brand-pill[data-brand="Sheba"] {
+      @apply bg-red-500;
+    }
+    
+    .brand-pill[data-brand="Blue Buffalo"] {
+      @apply bg-green-500;
     }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -55,6 +55,6 @@
     }
 
     .feedings .card {
-      @apply bg-white rounded-2xl shadow-md overflow-hidden border border-gray-200 flex items-center justify-start text-left px-4 py-4;
+      @apply bg-white rounded-2xl shadow-md overflow-hidden border border-gray-200 flex items-center justify-start text-left px-4 py-4 mb-4;
     }
 }

--- a/lib/pet_meals_web/live/feeding_live/index.ex
+++ b/lib/pet_meals_web/live/feeding_live/index.ex
@@ -131,9 +131,12 @@ defmodule PetMealsWeb.FeedingLive.Index do
     ~H"""
     <div class="card">
       <%!-- {@feedings.id} --%>
-      {@feedings.brand}
-      {@feedings.flavor}
-      {@feedings.portion}
+      <span class="brand-pill" data-brand={@feedings.brand}>
+        {@feedings.brand}
+      </span>
+      <div class="py-2">
+        {@feedings.flavor} - {@feedings.portion}
+      </div>
     </div>
     """
   end

--- a/lib/pet_meals_web/live/feeding_live/index.ex
+++ b/lib/pet_meals_web/live/feeding_live/index.ex
@@ -14,7 +14,7 @@ defmodule PetMealsWeb.FeedingLive.Index do
       |> assign(:brands, ["Sheba", "Fancy Feast", "Blue Buffalo"])
       |> assign(:flavors, ["Beef", "Salmon", "Turkey"])
       |> assign(:portions, ["full", "half", "quarter"])
-      |> stream(:feedings, Feedings.list_feedings() |> Enum.reverse())
+      |> stream(:feedings, Feedings.list_feedings())
 
     {:ok, socket}
   end
@@ -100,7 +100,11 @@ defmodule PetMealsWeb.FeedingLive.Index do
       {@page_title}
     </.header>
 
-    <.feeding_table streams={@streams} />
+    <%!-- <.feeding_table streams={@streams} /> --%>
+
+    <div class="feedings flex flex-col-reverse" id="feedings" phx-update="stream">
+      <.feeding_card :for={{_dom_id, feeding} <- @streams.feedings} feedings={feeding} />
+    </div>
     """
   end
 
@@ -120,6 +124,14 @@ defmodule PetMealsWeb.FeedingLive.Index do
         {feedings.portion}
       </:col>
     </.table>
+    """
+  end
+
+  def feeding_card(assigns) do
+    ~H"""
+    <div class="card">
+      {@feedings.id} {@feedings.brand} {@feedings.flavor} {@feedings.portion}
+    </div>
     """
   end
 
@@ -183,7 +195,7 @@ defmodule PetMealsWeb.FeedingLive.Index do
           |> assign(:selected_brand, nil)
           |> assign(:selected_flavor, nil)
           |> assign(:selected_portion, nil)
-          |> stream_insert(:feedings, feeding, at: 0)
+          |> stream_insert(:feedings, feeding, at: -1)
 
         {:noreply, socket}
     end

--- a/lib/pet_meals_web/live/feeding_live/index.ex
+++ b/lib/pet_meals_web/live/feeding_live/index.ex
@@ -130,7 +130,10 @@ defmodule PetMealsWeb.FeedingLive.Index do
   def feeding_card(assigns) do
     ~H"""
     <div class="card">
-      {@feedings.id} {@feedings.brand} {@feedings.flavor} {@feedings.portion}
+      <%!-- {@feedings.id} --%>
+      {@feedings.brand}
+      {@feedings.flavor}
+      {@feedings.portion}
     </div>
     """
   end


### PR DESCRIPTION
This is a submission for an initial change to the way that the feedings are displayed on the page, using `<.feeding_cards>` with CSS styling instead of the table. The cards span to the width of mobile devices but also look okay on a browser.  Additionally, added an inner "pill" for the brand as a proof of concept.

![image](https://github.com/user-attachments/assets/dc690fe7-1710-4a0e-a57b-aa5b88afa61a)

![image](https://github.com/user-attachments/assets/ebbb2ced-fb72-4e9d-81da-71dc82a424fa)
